### PR TITLE
Get projects based on Drive Name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 
 api_keys.json
+*test_requests.http
+.vscode/*

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -15,7 +15,7 @@ from models.member import Member
 from models.person import Person
 from models.project import InputProject, Project
 from models.role import prepopulate_roles
-from models.services import ResearchDriveService, Services
+from models.services import ResearchDriveService
 
 # Ensure driveoff directory is created
 (Path.home() / ".driveoff").mkdir(exist_ok=True)
@@ -106,9 +106,7 @@ async def set_drive_info(
         ResearchDriveService.model_validate(drive)
         for drive in input_project.services.research_drive
     ]
-    stored_services = Services(research_drive=drives)
-    # Add the validated services and members into the project
-    project.services = stored_services
+    project.research_drives = drives
     project.members = members
     # Upsert the project.
     session.merge(project)
@@ -149,11 +147,9 @@ async def get_drive_info(
     if drive_found is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Research Drive ID {drive_id} not found in local database",
+            detail=f"Research Drive ID {drive_id} not found in local database.",
         )
-    projects = [
-        projects for services in drive_found.service for projects in services.projects
-    ]
+    projects = drive_found.projects
     if len(projects) == 0:
         raise HTTPException(
             status_code=404,
@@ -161,6 +157,6 @@ async def get_drive_info(
         )
     return {
         "drive_id": drive_id,
-        "ro_crate": "TODO: Make RO-Crate from: " + str(projects[0]),
+        "ro_crate": "TODO: Make RO-Crate from: " + str(projects),
         "manifest": "TODO: Make Manifest",
     }

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -5,10 +5,10 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated, AsyncGenerator, Iterable
 
-from fastapi import Depends, FastAPI, Security
+from fastapi import Depends, FastAPI, HTTPException, Security
 from pydantic.functional_validators import AfterValidator
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from api.security import ApiKey, validate_api_key, validate_permissions
 from models.member import Member
@@ -135,15 +135,32 @@ async def append_drive_info(
 @app.get(ENDPOINT_PREFIX + "/resdriveinfo")
 async def get_drive_info(
     drive_id: ResearchDriveID,
-    # session: SessionDep,
+    session: SessionDep,
     api_key: ApiKey = Security(validate_api_key),
 ) -> dict[str, str]:
     """Retrieve information about the specified Research Drive."""
 
     validate_permissions("GET", api_key)
 
+    code_query = select(ResearchDriveService).where(
+        ResearchDriveService.name == drive_id
+    )
+    drive_found = session.exec(code_query).first()
+    if drive_found is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Research Drive ID {drive_id} not found in local database",
+        )
+    projects = [
+        projects for services in drive_found.service for projects in services.projects
+    ]
+    if len(projects) == 0:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No Projects associated with {drive_id} in local database",
+        )
     return {
         "drive_id": drive_id,
-        "ro_crate": "TODO: Make RO-Crate",
-        "manifest": "TODO: Make manifest",
+        "ro_crate": "TODO: Make RO-Crate from: " + str(projects[0]),
+        "manifest": "TODO: Make Manifest",
     }

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -6,8 +6,11 @@ from typing import TYPE_CHECKING, Optional
 from sqlmodel import Field, Relationship, SQLModel
 
 from models.person import InputPerson
-from models.services import (InputServices, ResearchDriveProjectLink,
-                             ResearchDriveService)
+from models.services import (
+    InputServices,
+    ResearchDriveProjectLink,
+    ResearchDriveService,
+)
 
 # Only import Member during typechecking to prevent circular dependency error.
 if TYPE_CHECKING:

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Optional
 from sqlmodel import Field, Relationship, SQLModel
 
 from models.person import InputPerson
-from models.services import InputServices, Services
+from models.services import (InputServices, ResearchDriveProjectLink,
+                             ResearchDriveService)
 
 # Only import Member during typechecking to prevent circular dependency error.
 if TYPE_CHECKING:
@@ -52,9 +53,11 @@ class Project(BaseProject, table=True):
     """Project model for data stored in database"""
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    services_id: int | None = Field(default=None, foreign_key="services.id")
+    # services_id: int | None = Field(default=None, foreign_key="services.id")
     codes: list[Code] = Relationship(link_model=ProjectCodeLink)
-    services: Services = Relationship(back_populates="projects")
+    research_drives: list[ResearchDriveService] = Relationship(
+        link_model=ResearchDriveProjectLink, back_populates="projects"
+    )
     members: list["Member"] = Relationship(
         # cascade_delete enabled so session.merge() works for project save.
         back_populates="project",

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -54,7 +54,7 @@ class Project(BaseProject, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     services_id: int | None = Field(default=None, foreign_key="services.id")
     codes: list[Code] = Relationship(link_model=ProjectCodeLink)
-    services: Services = Relationship()
+    services: Services = Relationship(back_populates="projects")
     members: list["Member"] = Relationship(
         # cascade_delete enabled so session.merge() works for project save.
         back_populates="project",

--- a/src/models/services.py
+++ b/src/models/services.py
@@ -9,11 +9,11 @@ if TYPE_CHECKING:
     from models.project import Project
 
 
-class ResearchDriveServicesLink(SQLModel, table=True):
+class ResearchDriveProjectLink(SQLModel, table=True):
     """Linking table between research drive service and a project's service."""
 
-    service_id: int | None = Field(
-        default=None, foreign_key="services.id", primary_key=True
+    project_id: int | None = Field(
+        default=None, foreign_key="project.id", primary_key=True
     )
     research_drive_id: int | None = Field(
         default=None, foreign_key="researchdriveservice.id", primary_key=True
@@ -32,20 +32,12 @@ class ResearchDriveService(SQLModel, table=True):
     name: str
     percentage_used: float
     used_gb: float
-    service: list["Services"] = Relationship(link_model=ResearchDriveServicesLink)
+    projects: list["Project"] = Relationship(
+        link_model=ResearchDriveProjectLink, back_populates="research_drives"
+    )
 
 
 class InputServices(SQLModel):
     """Input object describing relevant storage services."""
 
     research_drive: list[ResearchDriveService]
-
-
-class Services(SQLModel, table=True):
-    """Object describing relevant storage services."""
-
-    id: Optional[int] = Field(default=None, primary_key=True)
-    projects: list["Project"] = Relationship(back_populates="services")
-    research_drive: list[ResearchDriveService] = Relationship(
-        link_model=ResearchDriveServicesLink, back_populates="service"
-    )

--- a/src/models/services.py
+++ b/src/models/services.py
@@ -1,9 +1,23 @@
 """Data models representing CeR services."""
 
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from models.project import Project
+
+
+class ResearchDriveServicesLink(SQLModel, table=True):
+    """Linking table between research drive service and a project's service."""
+
+    service_id: int | None = Field(
+        default=None, foreign_key="services.id", primary_key=True
+    )
+    research_drive_id: int | None = Field(
+        default=None, foreign_key="researchdriveservice.id", primary_key=True
+    )
 
 
 class ResearchDriveService(SQLModel, table=True):
@@ -18,17 +32,7 @@ class ResearchDriveService(SQLModel, table=True):
     name: str
     percentage_used: float
     used_gb: float
-
-
-class ResearchDriveServicesLink(SQLModel, table=True):
-    """Linking table between research drive service and a project's service."""
-
-    service_id: int | None = Field(
-        default=None, foreign_key="services.id", primary_key=True
-    )
-    research_drive_id: int | None = Field(
-        default=None, foreign_key="researchdriveservice.id", primary_key=True
-    )
+    service: list["Services"] = Relationship(link_model=ResearchDriveServicesLink)
 
 
 class InputServices(SQLModel):
@@ -41,6 +45,7 @@ class Services(SQLModel, table=True):
     """Object describing relevant storage services."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
+    projects: list["Project"] = Relationship(back_populates="services")
     research_drive: list[ResearchDriveService] = Relationship(
-        link_model=ResearchDriveServicesLink
+        link_model=ResearchDriveServicesLink, back_populates="service"
     )


### PR DESCRIPTION
Small update to services and project models to allow for getting a project based on a drive name along with addition to API main script to use a driveID to get all projects that have services containing a drive with a given name.

-Also added gitignores for testing and .vscode files.