### PR TITLE
Fix wrong CORS host address

### DIFF
--- a/modes/.env.production
+++ b/modes/.env.production
@@ -1,1 +1,1 @@
-CORS_ALLOW_HOST='["https://uoa-eresearch.github.io/driveoff/"]'
+CORS_ALLOW_HOST='["https://uoa-eresearch.github.io/"]'


### PR DESCRIPTION
This small PR fixes an issue in the CORS allow list production environment variable. Previously, the variable mistakenly included an invalid CORS allow list value.