### PR TITLE
Make CORS work properly

### DIFF
--- a/modes/.env.production
+++ b/modes/.env.production
@@ -1,1 +1,1 @@
-CORS_ALLOW_HOST='["https://uoa-eresearch.github.io/"]'
+CORS_ALLOW_HOST='["https://uoa-eresearch.github.io"]'


### PR DESCRIPTION
FastAPI didn't like the trailling slash in the CORS allow list.